### PR TITLE
Update Activity.vue

### DIFF
--- a/src/views/admin/controllers/Activity.vue
+++ b/src/views/admin/controllers/Activity.vue
@@ -52,6 +52,7 @@
 							<i class="type_controller material-icons right">{{controller.vis?'work':'home'}}</i>
 							<router-link :to="`/controllers/${controller.cid}`" class="controller_name">
 								<span class="bold">{{controller.fname}} {{controller.lname}}</span>
+								<span class= "bold" v-if="controller.absence.length !== 0"> (LOA)</span>
 								<div class="controller_info">
 									<h6>Controller Details</h6>
 									<p class="bold">{{controller.fname}} {{controller.lname}} ({{controller.oi}})</p>


### PR DESCRIPTION
Adds LOA next to user name if LOA is active and expires after the current date.

## [ZAU-42]

---

### Summary

What does this PR do?

This closes issue #41.
---

### DB Changes (if any)

- [] What is the change?

```
Adds (LOA) next to the user's name if they have active LOAs.
```

---

### Testing

1. Run all tests.
2. Additional testing requirements...

---

### Post-Deployment Validation

How to verify in the production environment.

---
View a user on LOA. it should have (LOA) next to their name.
---