### PR TITLE
Change minium solo cert time to 1 day, maximum to 45 days. Closes #98

### DIFF
--- a/src/views/instructor/solocerts/New.vue
+++ b/src/views/instructor/solocerts/New.vue
@@ -12,7 +12,7 @@
 						competency on the position they are receiving a solo certification for. <br /><br />Solo
 						certifications must be issued in accordance with the training syllabus and are
 						automatically submitted to VATUSA. <br /><br />Solo certifications may not extend beyond
-						30 days in length.
+						45 days in length.
 					</p>
 				</div>
 				<form class="col s12 l6 pull-l6" @submit.prevent="submitCert">
@@ -87,8 +87,8 @@ export default {
 
 		flatpickr(this.$refs.expirationDate, {
 			enableTime: false,
-			minDate: today,
-			maxDate: new Date(future.setDate(future.getDate() + 30)),
+			minDate: new Date(today.setDate(today.getDate() + 1)),
+			maxDate: new Date(future.setDate(future.getDate() + 45)),
 			disableMobile: true,
 			dateFormat: 'Y-m-d',
 			altFormat: 'Y-m-d',


### PR DESCRIPTION
## [ZAU-xxxx]

---

### Summary

Change the minimum time a solo cert can be issued to 1 day (to prevent VATUSA API rejection). Change the maximum time a solo cert can be issued to 45 days.

---

### DB Changes (if any)

- [] What is the change?

```
changes here
```

---

### Testing

1. Run all tests.
2. Additional testing requirements...

---

### Post-Deployment Validation

Create solo cert for 45 days and make sure it gets posted to VATUSA.

---
